### PR TITLE
update deploy workflows to trigger on pull requests with specific labels

### DIFF
--- a/.github/workflows/deploy_base64.yml
+++ b/.github/workflows/deploy_base64.yml
@@ -1,12 +1,13 @@
 name: deploy base64
 
 on:
-  push:
+  pull_request:
     branches:
-      - 'main'
+      - main
 
 jobs:
   bake:
+    if: contains(github.event.pull_request.labels.*.name, 'base64')
     name: Build docker image for base64 app and deploy to dokku
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy_portfolio.yml
+++ b/.github/workflows/deploy_portfolio.yml
@@ -1,12 +1,13 @@
 name: deploy portfolio
 
 on:
-  push:
+  pull_request:
     branches:
-      - 'main'
+      - main
 
 jobs:
   bake:
+    if: contains(github.event.pull_request.labels.*.name, 'portfolio')
     name: Build docker image for portfolio site and deploy to dokku
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request updates the deploy workflows to trigger on pull requests with specific labels. It adds conditions to the workflows so that they only run when the pull request contains the 'base64' or 'portfolio' label. This ensures that the workflows are triggered only for the relevant pull requests and avoids unnecessary deployments.