### PR TITLE
Fix GitHub Actions error when deploying sites

### DIFF
--- a/apps/portfolio/Dockerfile
+++ b/apps/portfolio/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:21-alpine AS base
 RUN npm --no-update-notifier --no-fund --global install pnpm
 ARG API_KEY
 ENV API_KEY=$API_KEY

--- a/apps/svelte-base64/Dockerfile
+++ b/apps/svelte-base64/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:21-alpine AS base
 RUN npm --no-update-notifier --no-fund --global install pnpm
 ARG PACKAGE_PATH=apps/svelte-base64
 ARG DEPS_PATH=packages/shared-ui


### PR DESCRIPTION
This pull request fixes a GitHub Actions error that occurs when deploying sites. The error was caused by using an outdated version of the Node image in the Dockerfile. This PR updates the Node image to version 21-alpine, which resolves the error.